### PR TITLE
When creating the widget, set the checked state of the checkbox before connnecting its toggle signal...

### DIFF
--- a/toggle_labels_widget/toggle_labels_widget.py
+++ b/toggle_labels_widget/toggle_labels_widget.py
@@ -57,8 +57,8 @@ class LayerTreeToggleLabelsWidget(QWidget):
 
         # init from layer
         if self.layer.type() == QgsMapLayer.VectorLayer:
-            self.checkbox.toggled.connect(self.toggled)
             self.checkbox.setChecked(self.layer.labelsEnabled())
+            self.checkbox.toggled.connect(self.toggled)
 
     def toggled(self, active):
         """


### PR DESCRIPTION
… to avoid needless repaints.